### PR TITLE
Upgrade the aws sdk to 975.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile  "org.embulk:embulk-core:0.8.1"
     provided "org.embulk:embulk-core:0.8.1"
     compile  "com.amazonaws:aws-java-sdk-s3:1.11.975"
+    compile  "com.amazonaws:aws-java-sdk-sts:1.11.975"
     testCompile "junit:junit:4.+"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.1"
     provided "org.embulk:embulk-core:0.8.1"
-    compile  "com.amazonaws:aws-java-sdk-s3:1.11.271"
+    compile  "com.amazonaws:aws-java-sdk-s3:1.11.975"
     testCompile "junit:junit:4.+"
 }
 


### PR DESCRIPTION
@llibra 

Can you please review the PR?

Upgrading the sdk version to 975. This adds additional features including but not limited to the ability to use the `WebIdentityTokenCredentialsProvider` for authentication in the default provider chain.