### PR TITLE
Move the Java package of the Java files to org.embulk.output.s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.output.S3FileOutputPlugin"
+    mainClass = "org.embulk.output.s3.S3FileOutputPlugin"
     category = "output"
     type = "s3"
 }

--- a/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.embulk.output;
+package org.embulk.output.s3;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/org/embulk/output/s3/TestS3FileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/s3/TestS3FileOutputPlugin.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.embulk.output;
+package org.embulk.output.s3;
 
 public class TestS3FileOutputPlugin
 {


### PR DESCRIPTION
Its Java codes are located in the Java package `org.embulk.output`, but it should be `org.embulk.output.s3` now.