### PR TITLE
Nominate developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,26 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Manabu Takayama"
+                        email = "learn.libra@gmail.com"
+                    }
+                    developer {
+                        name = "Toyama Hiroshi"
+                        email = "toyama0919@gmail.com"
+                    }
+                    developer {
+                        name = "Civitaspo"
+                        email = "civitaspo@gmail.com"
+                    }
+                    developer {
+                        name = "Shohei Sutoh"
+                        email = "ss.aquari@gmail.com"
+                    }
+                    developer {
+                        name = "Hiroyuki Sato"
+                        email = "hiroysato@gmail.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
We're going to release JARs of `embulk-output-s3` to Maven Central from 1.6.0 (#20 and #22).

Maven Central needs the `<developers>` section available in `pom.xml`. In this chance, trying to nominate developers who have developed/contributed in `embulk-output-s3` from the Git log.