### PR TITLE
Handle S3 compatible storages such as MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **tmp_path**: temporary file directory. If null, it is associated with the default FileSystem. (string, default: null)
 - **tmp_path_prefix**: prefix of temporary files (string, default: 'embulk-output-s3-')
 - **canned_acl**: canned access control list for created objects ([enum](#cannedaccesscontrollist), default: null)
+- **use_path_style**: use path style request. This option is useful for S3 compatible storage such as minIO. (default: false)
 - **proxy_host**: proxy host to use when accessing AWS S3 via proxy. (string, default: null )
 - **proxy_port**: proxy port to use when accessing AWS S3 via proxy. (string, default: null )
 

--- a/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,10 @@ public class S3FileOutputPlugin
         @Config("canned_acl")
         @ConfigDefault("null")
         Optional<CannedAccessControlList> getCannedAccessControlList();
+
+        @Config("use_path_style")
+        @ConfigDefault("false")
+        Optional<Boolean> getUsePathStyle();
     }
 
     public static class S3FileOutput
@@ -157,6 +162,12 @@ public class S3FileOutputPlugin
 
             if (task.getEndpoint().isPresent()) {
                 client.setEndpoint(task.getEndpoint().get());
+            }
+
+            if (task.getUsePathStyle().isPresent()) {
+                if (task.getUsePathStyle().get()) {
+                    client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
+                }
             }
 
             return client;


### PR DESCRIPTION
This is minimal support for S3 compatible storage such as MinIO.

```console
$ docker run \
  -p 9000:9000 \
  -p 9001:9001 \
  -e "MINIO_ROOT_USER=AKIAEXAMPLEKEY" \
  -e "MINIO_ROOT_PASSWORD=P8AvMjug9c14v/K7MDENG/bPxRfiCYEXAMPLEKEY" \
  minio/minio server /data --console-address ":9001"
```

With this change, I confirmed that MinIO starts to handle object ingestion:

```console
$ cat store_info.log
321,aaa
356,zzz
859,"a,b c, d"
879,"a\"b\"c\"d\"de"
999,NULL
```

```yaml
in:
  type: file
  path_prefix: ./store_info
  parser:
    type: csv
    charset: UTF-8
    newline: LF
    delimiter: ','
    quote: '"'
    escape: '\'
    null_string: 'NULL'
    skip_header_lines: 0
    columns:
    - {name: store_code, type: string}
    - {name: store_name, type: string}

out:
  type: s3
  path_prefix: logs/out
  file_ext: .csv
  bucket: my-minio-bucket
  endpoint: http://127.0.0.1:9000
  access_key_id: AKIAEXAMPLEKEY
  secret_access_key: P8AvMjug9c14v/K7MDENG/bPxRfiCYEXAMPLEKEY
  use_path_style: true
  formatter:
    type: csv
```

![Screenshot 2021-08-12 at 01-16-51 MinIO Console](https://user-images.githubusercontent.com/700876/129065714-5d243a48-204c-44fd-9e82-0cc6db857bb1.png)

![Screenshot 2021-08-12 at 01-17-11 MinIO Console](https://user-images.githubusercontent.com/700876/129065737-b59bd4f0-852d-4676-a054-1103e54f0f09.png)


Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>